### PR TITLE
Support Launchpad Mini MK3 device name on Windows

### DIFF
--- a/src/launchpads/MK3/LaunchpadMK3.ts
+++ b/src/launchpads/MK3/LaunchpadMK3.ts
@@ -7,7 +7,7 @@ import { SysEx } from './SysEx.js';
 export type LaunchpadMK3Options = BaseLaunchpadOptions;
 
 export class LaunchpadMK3 extends BaseLaunchpad {
-  public static readonly DEFAULT_DEVICE_NAME = /^Launchpad.*MK3 MIDI/;
+  public static readonly DEFAULT_DEVICE_NAME = /^Launchpad.*MK3 MIDI|^MIDI.* \(LP.*MK3 MIDI\)/
 
   /**
    *


### PR DESCRIPTION
👋 Hello! Thanks a tonne for this library.

Everything was working well for macOS development, but I found that the library would error out on Windows, as the Launchpad registers itself under a different name there.

On windows I have:

```
# Input
[ 'LPMiniMK3 MIDI', 'MIDIIN2 (LPMiniMK3 MIDI)' ]

# Output
[ 'LPMiniMK3 MIDI', 'MIDIOUT2 (LPMiniMK3 MIDI)' ]
```

After a quick test, the `MIDIIN2` and `MIDIOUT2` devices are the midi interfaces needed. The `DEFAULT_DEVICE_CHANGE` regex tweak in this PR adds support for this device name alongside the macOS device name.

(NB: Need to be careful that the regex stays specific enough to _not_ pick the `LPMiniMK3 MIDI` devices as, despite the name, they appear to be the DAW interfaces in Windows. Thankfully they start with `LP` and not `Launchpad`)